### PR TITLE
support compile-time number conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ In addition to supporting the standard base 10 conversion, this implementation a
 your choice. Therefore, if you want a binary representation, set the base to 2. If you want hexadecimal, set the
 base to 16.
 
+## Supports Const Contexts
+
+This library's API includes `const` functions that can be used to convert numbers into their string representation at compile time, allowing developers to build smaller & faster executables.
+
 ## `&str` Example
 
 ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,16 +288,16 @@ macro_rules! impl_signed_numtoa_for {
     }
 }
 
-impl_signed_numtoa_for!(i16,numtoa_i16,numtoa_str_i16);
-impl_signed_numtoa_for!(i32,numtoa_i32,numtoa_str_i32);
-impl_signed_numtoa_for!(i64,numtoa_i64,numtoa_str_i64);
-impl_signed_numtoa_for!(i128,numtoa_i128,numtoa_str_i128);
-impl_signed_numtoa_for!(isize,numtoa_isize,numtoa_str_isize);
-impl_unsigned_numtoa_for!(u16,numtoa_u16,numtoa_str_u16);
-impl_unsigned_numtoa_for!(u32,numtoa_u32,numtoa_str_u32);
-impl_unsigned_numtoa_for!(u64,numtoa_u64,numtoa_str_u64);
-impl_unsigned_numtoa_for!(u128,numtoa_u128,numtoa_str_u128);
-impl_unsigned_numtoa_for!(usize,numtoa_usize,numtoa_str_usize);
+impl_signed_numtoa_for!(i16,numtoa_i16,numtoa_i16_str);
+impl_signed_numtoa_for!(i32,numtoa_i32,numtoa_i32_str);
+impl_signed_numtoa_for!(i64,numtoa_i64,numtoa_i64_str);
+impl_signed_numtoa_for!(i128,numtoa_i128,numtoa_i128_str);
+impl_signed_numtoa_for!(isize,numtoa_isize,numtoa_isize_str);
+impl_unsigned_numtoa_for!(u16,numtoa_u16,numtoa_u16_str);
+impl_unsigned_numtoa_for!(u32,numtoa_u32,numtoa_u32_str);
+impl_unsigned_numtoa_for!(u64,numtoa_u64,numtoa_u64_str);
+impl_unsigned_numtoa_for!(u128,numtoa_u128,numtoa_u128_str);
+impl_unsigned_numtoa_for!(usize,numtoa_usize,numtoa_usize_str);
 
 pub const fn numtoa_i8(mut num: i8, base: i8, string: &mut [u8]) -> &[u8] {
     if cfg!(debug_assertions) {
@@ -356,7 +356,7 @@ pub const fn numtoa_i8(mut num: i8, base: i8, string: &mut [u8]) -> &[u8] {
     string.split_at(index.wrapping_add(1)).1
 }
 
-pub const fn numtoa_str_i8(num: i8, base: i8, string: &mut [u8]) -> &str {
+pub const fn numtoa_i8_str(num: i8, base: i8, string: &mut [u8]) -> &str {
     unsafe { str::from_utf8_unchecked(numtoa_i8(num, base, string)) }
 }
 
@@ -366,7 +366,7 @@ impl NumToA for i8 {
     }
 
     fn numtoa_str(self, base: Self, buf: &mut [u8]) -> &str {
-        numtoa_str_i8(self, base, buf)
+        numtoa_i8_str(self, base, buf)
     }
 }
 
@@ -409,7 +409,7 @@ pub const fn numtoa_u8(mut num: u8, base: u8, string: &mut [u8]) -> &[u8] {
     string.split_at(1).1
 }
 
-pub const fn numtoa_str_u8(num: u8, base: u8, string: &mut [u8]) -> &str {
+pub const fn numtoa_u8_str(num: u8, base: u8, string: &mut [u8]) -> &str {
     unsafe { str::from_utf8_unchecked(numtoa_u8(num, base, string)) }
 }
 
@@ -419,7 +419,7 @@ impl NumToA for u8 {
     }
 
     fn numtoa_str(self, base: Self, buf: &mut [u8]) -> &str {
-        numtoa_str_u8(self, base, buf)
+        numtoa_u8_str(self, base, buf)
     }
 }
 


### PR DESCRIPTION
# background

the `NumToA` trait is convenient, but currently cannot be used in [const contexts](https://doc.rust-lang.org/reference/const_eval.html#const-context)

we cannot define const functions on the existing `NumToA` trait ([for now](https://github.com/rust-lang/rfcs/pull/2632)), so instead, we can define `const` library functions. this change will allow numtoa to **convert numbers into strings 100% at compile time!**

the PR contains mostly simple refactors to move the core logic into `const` functions of the format `numtoa_u16`, `numtoa_str_u16`, etc. and is fully backwards compatible, with the following notable changes:
1. slicing doesn't work in const contexts, so `copy_from_slice` was replaced with a new macro `copy_2_dec_lut_bytes`
2. slicing doesn't work in const contexts, so `&string[x..]` was replaced with `string.split_at(x).1`
3. macros were renamed from "sized/unsized" to "signed/unsigned" (i think this was a typo)

here is a usage example of the new const functions:

```
extern crate numtoa;

use numtoa::{numtoa_u16, NumToA};

const NUMBER: u16 = 12345;
const BUFFER_AND_LEN: ([u8; 20], usize) = {
    let mut buffer = [0_u8; 20];
    // our new function! 12345.numtoa() is not const so cannot be used here
    let n = numtoa_u16(NUMBER, 10, &mut buffer).len();
    (buffer, n)
};
const STRING: &str = unsafe { core::str::from_utf8_unchecked(BUFFER_AND_LEN.0.split_at(BUFFER_AND_LEN.0.len() - BUFFER_AND_LEN.1).1) };

fn main() {
    println!("hello world: {}", STRING);
}
```

the number `12345` is converted to ascii form purely at compile time. if we inspect the binary, we can see that numtoa code is not present in the final binary. using the `strings` tool additionally shows that the decimal lookup table is not present, whereas it is easily noticeable in a binary that was compiled with e.g. `println!("hello world: {}", 12345.numtoa_str(10, &mut [0_u8; 20]));` making the code much more efficient.

the boilerplate code is a bit unfortunate & unwieldy but i have a future PR that will make compile-time conversion much easier & more ergonomic as a one-liner.