### PR TITLE
streamlined base N conversion API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -489,11 +489,13 @@ pub mod base10 {
         $core_function_name:ident,
         $base10_function_name:ident,
         $needed_buffer_size:expr) => {
+
             pub const fn $base10_function_name(num: $type_name) -> AsciiNumber<$needed_buffer_size> {
                 let mut string = [0_u8; $needed_buffer_size];
                 let len = $core_function_name(num, 10, &mut string).len();
                 return AsciiNumber { string, start:$needed_buffer_size-len}
             }
+
         };
     }
 
@@ -502,7 +504,7 @@ pub mod base10 {
     impl_numtoa_base10_init_for!(u32,numtoa_u32,u32,10); // 4294967295
     impl_numtoa_base10_init_for!(u64,numtoa_u64,u64,20); // 18446744073709551615
     impl_numtoa_base10_init_for!(u128,numtoa_u128,u128,39); // 340282366920938463463374607431768211455
-    impl_numtoa_base10_init_for!(i8,numtoa_i8,i8,3); // -128
+    impl_numtoa_base10_init_for!(i8,numtoa_i8,i8,4); // -128
     impl_numtoa_base10_init_for!(i16,numtoa_i16,i16,6); // -32768
     impl_numtoa_base10_init_for!(i32,numtoa_i32,i32,11); // -2147483648
     impl_numtoa_base10_init_for!(i64,numtoa_i64,i64,20); // -9223372036854775808

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -479,7 +479,7 @@ macro_rules! impl_numtoa_base_n_init_for {
 
         pub const fn $base_n_function_name(num: $type_name) -> AsciiNumber<$needed_buffer_size> {
             let mut string = [0_u8; $needed_buffer_size];
-            let len = $core_function_name(num, 10, &mut string).len();
+            let len = $core_function_name(num, $base, &mut string).len();
             return AsciiNumber { string, start:$needed_buffer_size-len}
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,9 +126,9 @@ const DEC_LOOKUP: &[u8; 200] = b"0001020304050607080910111213141516171819\
                                  6061626364656667686970717273747576777879\
                                  8081828384858687888990919293949596979899";
 
-/// The result of a number conversion to ascii containing a string with maximum length `BUFFER_SIZE`
-pub struct AsciiNumber<const BUFFER_SIZE: usize> {
-    string: [u8; BUFFER_SIZE],
+/// The result of a number conversion to ascii containing a string with at most length `N` bytes/characters
+pub struct AsciiNumber<const N: usize> {
+    string: [u8; N],
     start: usize,
 }
 
@@ -469,6 +469,23 @@ impl NumToA for u8 {
     }
 }
 
+macro_rules! impl_numtoa_base_n_init_for {
+(
+    $type_name:ty,
+    $base:expr,
+    $core_function_name:ident,
+    $base_n_function_name:ident,
+    $needed_buffer_size:expr) => {
+
+        pub const fn $base_n_function_name(num: $type_name) -> AsciiNumber<$needed_buffer_size> {
+            let mut string = [0_u8; $needed_buffer_size];
+            let len = $core_function_name(num, 10, &mut string).len();
+            return AsciiNumber { string, start:$needed_buffer_size-len}
+        }
+
+    };
+}
+
 pub mod base10 {
 
     use AsciiNumber;
@@ -483,32 +500,16 @@ pub mod base10 {
     use numtoa_i64;
     use numtoa_i128;
 
-    macro_rules! impl_numtoa_base10_init_for {
-    (
-        $type_name:ty,
-        $core_function_name:ident,
-        $base10_function_name:ident,
-        $needed_buffer_size:expr) => {
-
-            pub const fn $base10_function_name(num: $type_name) -> AsciiNumber<$needed_buffer_size> {
-                let mut string = [0_u8; $needed_buffer_size];
-                let len = $core_function_name(num, 10, &mut string).len();
-                return AsciiNumber { string, start:$needed_buffer_size-len}
-            }
-
-        };
-    }
-
-    impl_numtoa_base10_init_for!(u8,numtoa_u8,u8,3); // 255
-    impl_numtoa_base10_init_for!(u16,numtoa_u16,u16,5); // 65535
-    impl_numtoa_base10_init_for!(u32,numtoa_u32,u32,10); // 4294967295
-    impl_numtoa_base10_init_for!(u64,numtoa_u64,u64,20); // 18446744073709551615
-    impl_numtoa_base10_init_for!(u128,numtoa_u128,u128,39); // 340282366920938463463374607431768211455
-    impl_numtoa_base10_init_for!(i8,numtoa_i8,i8,4); // -128
-    impl_numtoa_base10_init_for!(i16,numtoa_i16,i16,6); // -32768
-    impl_numtoa_base10_init_for!(i32,numtoa_i32,i32,11); // -2147483648
-    impl_numtoa_base10_init_for!(i64,numtoa_i64,i64,20); // -9223372036854775808
-    impl_numtoa_base10_init_for!(i128,numtoa_i128,i128,40); // -170141183460469231731687303715884105728
+    impl_numtoa_base_n_init_for!(u8,10,numtoa_u8,u8,3); // 255
+    impl_numtoa_base_n_init_for!(u16,10,numtoa_u16,u16,5); // 65535
+    impl_numtoa_base_n_init_for!(u32,10,numtoa_u32,u32,10); // 4294967295
+    impl_numtoa_base_n_init_for!(u64,10,numtoa_u64,u64,20); // 18446744073709551615
+    impl_numtoa_base_n_init_for!(u128,10,numtoa_u128,u128,39); // 340282366920938463463374607431768211455
+    impl_numtoa_base_n_init_for!(i8,10,numtoa_i8,i8,4); // -128
+    impl_numtoa_base_n_init_for!(i16,10,numtoa_i16,i16,6); // -32768
+    impl_numtoa_base_n_init_for!(i32,10,numtoa_i32,i32,11); // -2147483648
+    impl_numtoa_base_n_init_for!(i64,10,numtoa_i64,i64,20); // -9223372036854775808
+    impl_numtoa_base_n_init_for!(i128,10,numtoa_i128,i128,40); // -170141183460469231731687303715884105728
 
 }
 


### PR DESCRIPTION
## background
this PR adds a new API to convert numbers to ascii with an automatically provided buffer that is returned to the caller. this allows for incredibly simple compile-time initialization - where before we had to explicitly define an extra boilerplate constant:

```
const BOILERPLATE: ([u8; 20], usize) = {
    let mut buffer = [0_u8; 20];
    let n = numtoa_u16(12345, 10, &mut buffer).len();
    (buffer, n)
};
const STRING: &str = unsafe { core::str::from_utf8_unchecked(BOILERPLATE.0.split_at(BOILERPLATE.0.len() - BOILERPLATE.1).1) };
```

we can now achieve the same compile-time evaluation with an incredibly simple one liner:
```
const STRING: &str = base10::u16(12345).as_str();
```

this is not only more ergonomic for many use cases, it is also safer  and can likely be made panic-free because the buffer is always the correct size. notice how the function return type statically guarantees the buffer size.
![image](https://github.com/user-attachments/assets/9d5b70cf-e913-4af7-bdae-1cda8cec6858)


the juice behind this API is the new immutable struct `AsciiNumber<const N: usize>` which is a fancy wrapper around what is essentially `([u8; N], usize)` - this takes advantage of the fact that [we already know the required buffer widths for base 10](https://github.com/mmstick/numtoa/blob/3c82d9d6d3ca92a2e8836a73ea768e74b4a217d7/src/lib.rs#L178-L181)

`AsciiNumber` implements `Display` & `Debug`, and additionally dereferences into a plain old string slice, making it an incredibly easy to use drop-in replacement for a string slice, arguably better than `String`. this PR only implements base 10 but i have added a macro `impl_numtoa_base_n_init_for` that we can use to easily extend this API to any base. `usize` and `isize` aren't yet supported because their width is variable & we would need to map the pointer width to the numeric base to the necessary buffer size at compile time and i'm not sure the best way to do that.

basically, the existing API is still superior when reusing the buffer is appropriate. the new API shines when it comes to one-off conversions & constant initialization.

## change

* add new `AsciiNumber` struct
* add new `base10` module with one function per numeric type that returns an owned `AsciiNumber`
* update & add unit tests to cover new code paths (base10 entry & const function entry)
* finish `const` implementations for signed numeric types

## demo
```
extern crate numtoa;

use numtoa::{base10, AsciiNumber};

// explicitly using AsciiNumber is ergonomic
const EXAMPLE_ONE: AsciiNumber<5> = base10::u16(12345);

// it can easily be used as a string slice
const EXAMPLE_TWO: &str = base10::i128(12345).as_str();

// it can easily be used as a byte slice
const EXAMPLE_THREE: &[u8] = base10::u16(12345).as_slice();

fn main() {
    println!("const init example 1 - AsciiNumber: {}", EXAMPLE_ONE);
    println!("const init example 2 - &str: {}", EXAMPLE_TWO);
    println!("const init example 3 - &[u8]: {}", std::str::from_utf8(EXAMPLE_THREE).expect("ascii"));
    println!("const init example 4 - inlined: {}", const { base10::u32(12345) });

    println!("non-const init example 1 - explicit AsciiNumber: {}", base10::i64(12345));
    println!("non-const init example 2 - one-liner &str: {}", base10::i128(12345).as_str());
    println!("non-const init example 3 - one-liner &[u8]: {}", unsafe { core::str::from_utf8_unchecked(base10::i128(12345).as_slice()) } );

    println!("trait example 1 - Debug: {:?}", base10::i32(12345));
    println!("trait example 2 - Display: {}", base10::i64(12345));
    println!("trait example 3 - Deref<Target = str>: {:?}", base10::u128(12345).char_indices());
    println!("trait example 4 - Deref<Target = str>: {}", base10::u128(12345)
    .replace("1", "🤔")
    .replace("2", "😶")
    .replace("3", "😲")
    .replace("4", "😮")
    .replace("5", "😍"));
}
```
