### PR TITLE
add into_inner function on AsciiNumber

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,10 @@ impl <const N: usize> AsciiNumber<N> {
     pub const fn as_str(&self) -> &str {
         unsafe { core::str::from_utf8_unchecked(Self::as_slice(self)) }
     }
+    /// Get the underlying buffer & string start position
+    pub const fn into_inner(self) -> ([u8;N], usize) {
+        (self.string, self.start)
+    }
 }
 
 impl <const N: usize> Deref for AsciiNumber<N> {


### PR DESCRIPTION
## background
allow developers to get a reference to the underlying buffer in case they need it for whatever reason
1. just seems polite
2. this is a convenient way for developers to initialize a buffer of the correct size that can be reused with the normal `numtoa` API (for the same base & numeric type anyway)

## change
add a new const method `into_inner` that consumes an AsciiNumber to return the underlying buffer & string start position