### PR TITLE
support formatting numbers with padding

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -486,6 +486,7 @@ macro_rules! impl_numtoa_streamlined_for_type {
     $base:expr,
     $core_function_name:ident,
     $base_n_function_name:ident,
+    $padded_function_name:ident,
     $needed_buffer_size:expr) => {
 
         pub const fn $base_n_function_name(num: $type_name) -> AsciiNumber<$needed_buffer_size> {
@@ -494,6 +495,12 @@ macro_rules! impl_numtoa_streamlined_for_type {
             return AsciiNumber { string, start:$needed_buffer_size-len}
         }
 
+        pub const fn $padded_function_name<const LENGTH: usize>(num: $type_name, padding: u8) -> AsciiNumber<LENGTH> {
+            const { assert!(LENGTH >= $needed_buffer_size) }
+            let mut string = [padding; LENGTH];
+            let _ = $core_function_name(num, $base, &mut string);
+            return AsciiNumber { string, start: 0 }
+        }
     };
 }
 
@@ -526,16 +533,16 @@ macro_rules! impl_numtoa_streamlined_for {
                 use numtoa_i64;
                 use numtoa_i128;
 
-                impl_numtoa_streamlined_for_type!(u8,$base_value,numtoa_u8,u8,$u8_needed_size);
-                impl_numtoa_streamlined_for_type!(u16,$base_value,numtoa_u16,u16,$u16_needed_size);
-                impl_numtoa_streamlined_for_type!(u32,$base_value,numtoa_u32,u32,$u32_needed_size);
-                impl_numtoa_streamlined_for_type!(u64,$base_value,numtoa_u64,u64,$u64_needed_size);
-                impl_numtoa_streamlined_for_type!(u128,$base_value,numtoa_u128,u128,$u128_needed_size);
-                impl_numtoa_streamlined_for_type!(i8,$base_value,numtoa_i8,i8,$i8_needed_size);
-                impl_numtoa_streamlined_for_type!(i16,$base_value,numtoa_i16,i16,$i16_needed_size);
-                impl_numtoa_streamlined_for_type!(i32,$base_value,numtoa_i32,i32,$i32_needed_size);
-                impl_numtoa_streamlined_for_type!(i64,$base_value,numtoa_i64,i64,$i64_needed_size);
-                impl_numtoa_streamlined_for_type!(i128,$base_value,numtoa_i128,i128,$i128_needed_size);
+                impl_numtoa_streamlined_for_type!(u8,$base_value,numtoa_u8,u8,u8_padded,$u8_needed_size);
+                impl_numtoa_streamlined_for_type!(u16,$base_value,numtoa_u16,u16,u16_padded,$u16_needed_size);
+                impl_numtoa_streamlined_for_type!(u32,$base_value,numtoa_u32,u32,u32_padded,$u32_needed_size);
+                impl_numtoa_streamlined_for_type!(u64,$base_value,numtoa_u64,u64,u64_padded,$u64_needed_size);
+                impl_numtoa_streamlined_for_type!(u128,$base_value,numtoa_u128,u128,u128_padded,$u128_needed_size);
+                impl_numtoa_streamlined_for_type!(i8,$base_value,numtoa_i8,i8,i8_padded,$i8_needed_size);
+                impl_numtoa_streamlined_for_type!(i16,$base_value,numtoa_i16,i16,i16_padded,$i16_needed_size);
+                impl_numtoa_streamlined_for_type!(i32,$base_value,numtoa_i32,i32,i32_padded,$i32_needed_size);
+                impl_numtoa_streamlined_for_type!(i64,$base_value,numtoa_i64,i64,i64_padded,$i64_needed_size);
+                impl_numtoa_streamlined_for_type!(i128,$base_value,numtoa_i128,i128,i128_padded,$i128_needed_size);
         }
     };
 }
@@ -643,8 +650,24 @@ fn str_convenience_base10() {
 }
 
 #[test]
+fn str_convenience_base10_padded() {
+    assert_eq!("00000000000000256123", base10::i32_padded::<20>(256123, b'0').as_str());
+}
+
+#[test]
 fn str_convenience_base16() {
     assert_eq!("3E87B", base16::i32(256123).as_str());
+}
+
+#[test]
+fn str_convenience_base16_padded() {
+    assert_eq!("0000000000000003E87B", base16::i32_padded::<20>(256123, b'0').as_str());
+}
+
+#[test]
+fn str_convenience_wacky_padding() {
+    assert_eq!("##############-3E87B", base16::i32_padded::<20>(-256123, b'#').as_str());
+    assert_eq!("@@@@@@@@@@@-111", base10::i8_padded::<15>(-111, b'@').as_str());
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -491,8 +491,8 @@ macro_rules! impl_numtoa_streamlined_for_type {
 
         pub const fn $base_n_function_name(num: $type_name) -> AsciiNumber<$needed_buffer_size> {
             let mut string = [0_u8; $needed_buffer_size];
-            let len = $core_function_name(num, $base, &mut string).len();
-            return AsciiNumber { string, start:$needed_buffer_size-len}
+            let start = $needed_buffer_size - $core_function_name(num, $base, &mut string).len();
+            return AsciiNumber { string, start }
         }
 
         pub const fn $padded_function_name<const LENGTH: usize>(num: $type_name, padding: u8) -> AsciiNumber<LENGTH> {


### PR DESCRIPTION
## background

feature request: https://github.com/mmstick/numtoa/issues/15

this PR will allow for automatically padding numbers initialized using the streamlined API. works at compile-time. (not sure the best way to implement this in the normal API)

## change
add a new set of functions in the streamlined API `u8_padded`, `u16_padded`, etc. that allow for initializing ascii numbers with padding to a user-defined but constant length, that is statically verified to be at least the size of of the number itself.

`base16::i32_padded::<1>(256123, b'0')` fails to compile, but ` base16::i32_padded::<9>(256123, b'0')` works fine.

also add some tests

## example usage
```
assert_eq!("00000000000000256123", base10::i32_padded::<20>(256123, b'0').as_str())
```