### PR TITLE
add more categories to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ documentation = "https://docs.rs/numtoa"
 description = "Convert numbers into stack-allocated byte arrays"
 repository = "https://github.com/mmstick/numtoa"
 keywords = ["numbers", "convert", "numtoa", "itoa", "no_std"]
-categories = ["value-formatting"]
+categories = ["value-formatting", "no-std", "no-std::no-alloc", "embedded"]
 readme = "README.md"


### PR DESCRIPTION
we can have up to five categories - added "no-std", "no-std::no-alloc", & "embedded"