### PR TITLE
bump version 0.3.1 -> 0.3.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "numtoa"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Michael Aaron Murphy <mmstickman@gmail.com>"]
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/numtoa"


### PR DESCRIPTION
shall we do a new release? we have some major changes like arbitrary base support in const, API improvements, new crates.io categories.

also, it would be great to push the `0.3.2` tag to github as well, thanks!