### PR TITLE
Support formatting numbers with filling

### DIFF
--- a/src/numtoa_const.rs
+++ b/src/numtoa_const.rs
@@ -130,7 +130,7 @@ macro_rules! impl_numtoa_const_for_base_on_type {
             num: $type_name,
             fill: u8,
         ) -> AsciiNumber<{ Self::$required_space_constant_name }> {
-            const { assert!(LENGTH < { Self::$required_space_constant_name }) }
+            const { assert!(LENGTH <= { Self::$required_space_constant_name }) }
             let mut string = [fill; Self::$required_space_constant_name];
             let start = Self::$required_space_constant_name
                 - const_max(LENGTH, $core_function_name(num, $base, &mut string).len());


### PR DESCRIPTION
Closes #15.

PR #30 only supported leading characters with `LENGTH >= needed_space`, it's still hard to replace std formatting `{:03}` for integer types like `u32`.

This PR adds new functions `{integer}_filled` which allows leading characters with `LENGTH < needed_space`.