### PR TITLE
fix bug in AsciiNumber constant

### DIFF
--- a/src/numtoa_const.rs
+++ b/src/numtoa_const.rs
@@ -30,7 +30,7 @@ impl<const N: usize> AsciiNumber<N> {
 
     pub const ONE: AsciiNumber<N> = {
         let mut string = [0_u8; N];
-        string[N - 1] = b'0';
+        string[N - 1] = b'1';
         let start = N - 1;
         AsciiNumber { string, start }
     };

--- a/src/numtoa_const.rs
+++ b/src/numtoa_const.rs
@@ -283,6 +283,12 @@ impl_numtoa_const_for_base_n!(15);
 impl_numtoa_const_for_base_n!(16);
 
 #[test]
+fn ascii_number_constants() {
+    assert_eq!("0", AsciiNumber::<4>::ZERO.as_str());
+    assert_eq!("1", AsciiNumber::<4>::ONE.as_str());
+}
+
+#[test]
 fn str_convenience_base2() {
     assert_eq!("111110100001111011", BaseN::<2>::i32(256123).as_str());
 }


### PR DESCRIPTION
`AsciiNumber::<4>::ONE` was being set to zero instead of one

this PR fixes this + add unit tests